### PR TITLE
Add lint and mypy CI jobs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,21 @@
+name: Lint
+
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: psf/black@stable
+        with:
+          options: "--check --diff --color"
+          src: "."
+          version: "~= 23.3.0"
+      - uses: isort/isort-action@master
+        with:
+          sort-paths: pretraining
+          requirementsFiles: "requirements.txt" # We don't need extra test requirements for linting

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,5 +17,5 @@ jobs:
           version: "~= 23.3.0"
       - uses: isort/isort-action@master
         with:
-          sort-paths: pretraining
+          sort-paths: .
           requirementsFiles: "requirements.txt" # We don't need extra test requirements for linting

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,0 +1,54 @@
+# This workflow will install Python dependencies and run MyPy
+
+name: MyPy Type Checking
+
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      id: setup_python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+    - name: Restore Virtualenv
+      uses: actions/cache/restore@v4
+      id: cache-venv-restore
+      with:
+        path: ./.venv/
+        key: ${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-venv-${{ hashFiles('*requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-venv-
+    - name: Install dependencies
+      run: |
+        # Create the virtual environment
+        python -m venv .venv
+        . ./.venv/bin/activate
+
+        # Install the dependencies
+        # In case of a cache hit on the primary key, this will be a no-op
+        # In case of a cache miss, but hit on a secondary key, this will update what's changed
+        python -m pip install --upgrade pip
+        pip install -r test-requirements.txt
+
+        # Enables the virtual env for following steps
+        echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
+        echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
+        
+    - name: Test with pytest
+      run: |
+        mypy pretraining
+
+    - name: Save Virtualenv
+      id: cache-venv-save
+      uses: actions/cache/save@v4
+      with:
+        path: ./.venv/
+        key: ${{ steps.cache-venv-restore.outputs.cache-primary-key }}

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -42,9 +42,13 @@ jobs:
         echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
         echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
         
-    - name: Test with pytest
+    - name: Test with mypy
       run: |
-        mypy pretraining
+        # Install ibm-fms from the main branch for testing purposes
+        pip install ibm-fms@git+https://github.com/foundation-model-stack/foundation-model-stack@main
+
+        # No type stubs available for "fire" and "transformers"
+        mypy --exclude fms_to_hf.py --exclude main_training.py .
 
     - name: Save Virtualenv
       id: cache-venv-save

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,8 @@
+[settings]
+ensure_newline_before_comments = True
+force_grid_wrap = 0
+include_trailing_comma = True
+lines_after_imports = 2
+multi_line_output = 3
+use_parentheses = True
+profile = black

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# fms-train
+# fms-pretrain

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# fms-pretrain
+# pretrain

--- a/fms_to_hf.py
+++ b/fms_to_hf.py
@@ -24,9 +24,9 @@ def convert_to_hf(model: LLaMA) -> LlamaForCausalLM:
                 int(hf_config.hidden_size * hf_config.hidden_grow_factor)
                 / hf_config.multiple_of
             ),
-            pad_token_id=None
-            if hf_config.pad_token_id == -1
-            else hf_config.pad_token_id,
+            pad_token_id=(
+                None if hf_config.pad_token_id == -1 else hf_config.pad_token_id
+            ),
             bos_token_id=hf_config.bos_token_id,
             eos_token_id=hf_config.eos_token_id,
             max_position_embeddings=hf_config.max_expected_seq_len,

--- a/main_training.py
+++ b/main_training.py
@@ -83,11 +83,11 @@ def main(**kwargs):
         device_id=torch.cuda.current_device(),
         limit_all_gathers=True,
         sync_module_states=cfg.low_cpu_fsdp,
-        param_init_fn=lambda module: module.to_empty(
-            device=torch.device("cuda"), recurse=False
-        )
-        if cfg.low_cpu_fsdp
-        else None,
+        param_init_fn=lambda module: (
+            module.to_empty(device=torch.device("cuda"), recurse=False)
+            if cfg.low_cpu_fsdp
+            else None
+        ),
     )
 
     # fsdp activation checkpointing

--- a/pretraining/policies/ac_handler.py
+++ b/pretraining/policies/ac_handler.py
@@ -7,6 +7,7 @@ from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     checkpoint_wrapper,
 )
 
+
 non_reentrant_wrapper = partial(
     checkpoint_wrapper,
     checkpoint_impl=CheckpointImpl.NO_REENTRANT,

--- a/pretraining/policies/mixed_precision.py
+++ b/pretraining/policies/mixed_precision.py
@@ -1,6 +1,7 @@
 import torch
 from torch.distributed.fsdp import MixedPrecision
 
+
 fpSixteen = MixedPrecision(
     param_dtype=torch.float16,
     reduce_dtype=torch.float16,

--- a/pretraining/utils/dataset_utils.py
+++ b/pretraining/utils/dataset_utils.py
@@ -4,15 +4,7 @@ import math
 import os
 import random
 import sys
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Type,
-    Union,
-)
+from typing import Any, Callable, Dict, List, Optional, Type, Union
 
 import pyarrow as pa
 import torch

--- a/pretraining/utils/train_utils.py
+++ b/pretraining/utils/train_utils.py
@@ -1,13 +1,15 @@
 import os
+
+
 try:
     import packaging.version
 except ImportError:
     from pkg_resources import packaging  # type: ignore
+
 import time
 
 import torch.cuda.nccl as nccl
 import torch.distributed as dist
-
 from torch.distributed.fsdp import ShardingStrategy
 
 from pretraining.policies import *

--- a/pretraining/utils/train_utils.py
+++ b/pretraining/utils/train_utils.py
@@ -1,13 +1,12 @@
 import os
+try:
+    import packaging.version
+except ImportError:
+    from pkg_resources import packaging  # type: ignore
 import time
 
 import torch.cuda.nccl as nccl
 import torch.distributed as dist
-
-try:
-    import packaging.version
-except ImportError:
-    from pkg_resources import packaging
 
 from torch.distributed.fsdp import ShardingStrategy
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 torch>=2.1.0
-fire
-pyarrow
-transformers
+fire==0.5.0
+pyarrow==15.0.0
+transformers==4.37.2
+ibm-fms>=0.0.3

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -12,6 +12,3 @@ mypy-extensions==1.0.0
 pyarrow-stubs==10.0.1.7
 types-requests==2.31.0.20240125
 types-setuptools==69.0.0.20240125
-
-# Install ibm-fms from the main branch for testing purposes
-ibm-fms @ git+https://github.com/foundation-model-stack/foundation-model-stack@main

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -11,3 +11,7 @@ mypy-extensions==1.0.0
 # Types packages
 pyarrow-stubs==10.0.1.7
 types-requests==2.31.0.20240125
+types-setuptools==69.0.0.20240125
+
+# Install ibm-fms from the main branch for testing purposes
+ibm-fms @ git+https://github.com/foundation-model-stack/foundation-model-stack@main

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,13 @@
+# Used to install pinned test dependencies
+# Useful for dev/test jobs caches
+
+-r requirements.txt
+
+# Test tools
+black==24.1.1
+mypy==1.8.0
+mypy-extensions==1.0.0
+
+# Types packages
+pyarrow-stubs==10.0.1.7
+types-requests==2.31.0.20240125


### PR DESCRIPTION
Add CI jobs for:
- linting, using black
- type checking, using mypy

For CI jobs to pass, implement corresponding fixes:
- Automatic code reformat by black
- Added ibm-fms to requirements
- Ran no_implicit_optional (PEP 484 prohibits implicit Optional)
- Exclude files that depend on untyped packages
- Fix typing issues in dataset_util
